### PR TITLE
切换ip 可能会出现

### DIFF
--- a/FastDFS/Common/ConnectionManager.cs
+++ b/FastDFS/Common/ConnectionManager.cs
@@ -129,7 +129,8 @@ namespace FastDFS.Client
         public static Connection GetTrackerConnection()
         {
             Random random = new Random();
-            int index = random.Next(trackerPools.Count);
+            //int index = random.Next(trackerPools.Count);
+            int index = random.Next(listTrackers.Count); //Pool中的数据个数大于Trackers的
             Pool pool = trackerPools[listTrackers[index]];
             return pool.GetConnection();
         }


### PR DESCRIPTION
索引超出范围。必须为非负值并小于集合大小。
参数名: index